### PR TITLE
fix: Remove target blank attr from hash link

### DIFF
--- a/client/extensions/better-quill-link.js
+++ b/client/extensions/better-quill-link.js
@@ -10,7 +10,7 @@ class BetterQuillLink extends Link {
     value = this.sanitize(value);
     node.setAttribute('href', value);
 
-    if (value.startsWith('/')) {
+    if (value.startsWith('/') || value.startsWith('#')) {
       node.removeAttribute('target');
       node.removeAttribute('rel');
     }


### PR DESCRIPTION
Fix for a case with adding hash link and target=_blank comes together with link